### PR TITLE
Adds compatibility with the std image lib

### DIFF
--- a/webp.go
+++ b/webp.go
@@ -1,0 +1,23 @@
+package webp
+
+// Importing this package allows decoding of webp image files using the standard library's image.Decode.
+// It will clash with the golang.org/x/image/webp package
+
+import (
+	"image"
+	"io"
+
+	"github.com/kolesa-team/go-webp/webp"
+)
+
+func init() {
+	image.RegisterFormat("webp", "RIFF????WEBPVP8", quickDecode, quickDecodeConfig)
+}
+
+func quickDecode(r io.Reader) (image.Image, error) {
+	return webp.Decode(r, nil)
+}
+
+func quickDecodeConfig(r io.Reader) (image.Config, error) {
+	return webp.DecodeConfig(r, nil)
+}

--- a/webp/webp.go
+++ b/webp/webp.go
@@ -22,10 +22,12 @@
 package webp
 
 import (
+	"image"
+	"image/color"
+	"io"
+
 	"github.com/kolesa-team/go-webp/decoder"
 	"github.com/kolesa-team/go-webp/encoder"
-	"image"
-	"io"
 )
 
 // Decode picture from reader
@@ -35,6 +37,21 @@ func Decode(r io.Reader, options *decoder.Options) (image.Image, error) {
 	} else {
 		return dec.Decode()
 	}
+}
+
+// DecodeConfig extracts simple metadata without decoding the image
+func DecodeConfig(r io.Reader, options *decoder.Options) (image.Config, error) {
+	dec, err := decoder.NewDecoder(r, options)
+	if err != nil {
+		return image.Config{}, err
+	}
+
+	feat := dec.GetFeatures()
+	return image.Config{
+		ColorModel: color.NRGBAModel,
+		Width:      feat.Width,
+		Height:     feat.Height,
+	}, nil
 }
 
 // Encode encode picture and write to io.Writer


### PR DESCRIPTION
Adding `import _ "github.com/kolesa-team/go-webp"` to a file will allow `image.Decode` to automatically detect and decode WebP files using this library.

If this seems interesting/useful, I'll add tests and adapt where needed 😊

Replicates the approach used in [golang.org/x/image/webp](https://cs.opensource.google/go/x/image/+/master:webp/decode.go).
