### PR TITLE
Options.GetConfig handles nil caller gracefully

### DIFF
--- a/encoder/options.go
+++ b/encoder/options.go
@@ -26,7 +26,10 @@ package encoder
 #include <webp/encode.h>
 */
 import "C"
-import "errors"
+import (
+	"errors"
+	"fmt"
+)
 
 // Default libwebp image hints
 //noinspection GoUnusedConst
@@ -165,6 +168,13 @@ func (o *Options) boolToCInt(expression bool) (result C.int) {
 
 // GetConfig build WebPConfig for libwebp
 func (o *Options) GetConfig() (*C.WebPConfig, error) {
+	var err error
+	if o == nil {
+		o, err = NewLosslessEncoderOptions(PresetDefault, 0)
+		if err != nil {
+			return nil, fmt.Errorf("cannot validate default config: [%w]", err)
+		}
+	}
 	o.config.lossless = o.boolToCInt(o.Lossless)
 	o.config.quality = C.float(o.Quality)
 	o.config.method = C.int(o.Method)

--- a/encoder/options_test.go
+++ b/encoder/options_test.go
@@ -6,6 +6,15 @@ import (
 	"testing"
 )
 
+func TestNilOptions(t *testing.T) {
+	t.Run("config from nil Options succeeds", func(t *testing.T) {
+		var options *Options = nil
+		cfg, err := options.GetConfig()
+		require.NoError(t, err)
+		require.NotNil(t, cfg)
+	})
+}
+
 func TestNewLossyEncoderOptions(t *testing.T) {
 	t.Run("invalid quality", func(t *testing.T) {
 		options, err := NewLossyEncoderOptions(PresetDefault, -1)


### PR DESCRIPTION
Main goal: Make `webp.Encode` behave the same way as the [first-party image-type Encode methods](https://cs.opensource.google/go/go/+/refs/tags/go1.19.4:src/image/jpeg/writer.go;l=574); if it receives nil options, use defaults rather than panicking or returning an error. I'm not opinionated on whether this is the correct defaults (and in fact don't know what settings PresetDefault corresponds to).