### PR TITLE
Include minimum image bounds in calculation

### DIFF
--- a/encoder/encoder.go
+++ b/encoder/encoder.go
@@ -96,8 +96,8 @@ func (e *Encoder) Encode(w io.Writer) error {
 	output := C.encodeNRBBA(
 		e.config,
 		(*C.uint8_t)(&e.img.Pix[0]),
-		C.int(e.img.Rect.Max.X),
-		C.int(e.img.Rect.Max.Y),
+		C.int(e.img.Rect.Dx()),
+		C.int(e.img.Rect.Dy()),
 		C.int(e.img.Stride),
 		&size,
 	)


### PR DESCRIPTION
This fixes some strange behavior when you crop an image and then convert to webp.