### PR TITLE
Added compatibility with image.Decode

### DIFF
--- a/decoder/decoder.go
+++ b/decoder/decoder.go
@@ -59,6 +59,9 @@ func NewDecoder(r io.Reader, options *Options) (d *Decoder, err error) {
 		return nil, errors.New("data is empty")
 	}
 
+	if options == nil {
+		options = &Options{}
+	}
 	d = &Decoder{data: data, options: options}
 
 	if d.config, err = d.options.GetConfig(); err != nil {

--- a/decoder/decoder_test.go
+++ b/decoder/decoder_test.go
@@ -23,6 +23,7 @@ package decoder
 
 import (
 	"github.com/kolesa-team/go-webp/utils"
+	"github.com/stretchr/testify/require"
 	"image"
 	"os"
 	"testing"
@@ -103,4 +104,12 @@ func TestDecoder_GetFeatures(t *testing.T) {
 	if features.HasAlpha {
 		t.Fatal("file has_animation is invalid")
 	}
+}
+
+func TestDecoder_NilOptions(t *testing.T) {
+	file, err := os.Open("../test_data/images/m4_q75.webp")
+	require.NoError(t, err)
+
+	_, err = NewDecoder(file, nil)
+	require.NoError(t, err)
 }

--- a/encoder/encoder.go
+++ b/encoder/encoder.go
@@ -75,6 +75,9 @@ type Encoder struct {
 func NewEncoder(src image.Image, options *Options) (e *Encoder, err error) {
 	var config *C.WebPConfig
 
+	if options == nil {
+		options, _ = NewLossyEncoderOptions(PresetDefault, 75)
+	}
 	if config, err = options.GetConfig(); err != nil {
 		return nil, err
 	}

--- a/encoder/encoder_test.go
+++ b/encoder/encoder_test.go
@@ -5,7 +5,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"image"
-	"io/ioutil"
+	"os"
 	"testing"
 )
 
@@ -28,7 +28,7 @@ func TestNewEncoder(t *testing.T) {
 		err = e.Encode(expected)
 		require.NoError(t, err)
 
-		actual, err := ioutil.ReadFile("../test_data/images/100x150_lossy.webp")
+		actual, err := os.ReadFile("../test_data/images/100x150_lossy.webp")
 		require.NoError(t, err)
 
 		assert.Equal(t, actual, expected.Bytes())
@@ -51,9 +51,27 @@ func TestNewEncoder(t *testing.T) {
 		err = e.Encode(actuall)
 		require.NoError(t, err)
 
-		expected, err := ioutil.ReadFile("../test_data/images/100x150_lossless.webp")
+		expected, err := os.ReadFile("../test_data/images/100x150_lossless.webp")
 		require.NoError(t, err)
 
 		assert.Equal(t, expected, actuall.Bytes())
+	})
+}
+
+func TestNewEncoder_NilOptions(t *testing.T) {
+	t.Run("encode image without passing options should not panic", func(t *testing.T) {
+		expected := &bytes.Buffer{}
+		img := image.NewNRGBA(image.Rectangle{
+			Max: image.Point{
+				X: 100,
+				Y: 150,
+			},
+		})
+
+		e, err := NewEncoder(img, nil)
+		require.NoError(t, err)
+
+		err = e.Encode(expected)
+		require.NoError(t, err)
 	})
 }

--- a/webp/webp.go
+++ b/webp/webp.go
@@ -25,8 +25,21 @@ import (
 	"github.com/kolesa-team/go-webp/decoder"
 	"github.com/kolesa-team/go-webp/encoder"
 	"image"
+	"image/color"
 	"io"
 )
+
+func init() {
+	image.RegisterFormat("webp", "RIFF????WEBPVP8", quickDecode, quickDecodeConfig)
+}
+
+func quickDecode(r io.Reader) (image.Image, error) {
+	return Decode(r, &decoder.Options{})
+}
+
+func quickDecodeConfig(r io.Reader) (image.Config, error) {
+	return DecodeConfig(r, &decoder.Options{})
+}
 
 // Decode picture from reader
 func Decode(r io.Reader, options *decoder.Options) (image.Image, error) {
@@ -37,7 +50,19 @@ func Decode(r io.Reader, options *decoder.Options) (image.Image, error) {
 	}
 }
 
-// Encode encode picture and write to io.Writer
+func DecodeConfig(r io.Reader, options *decoder.Options) (image.Config, error) {
+	if dec, err := decoder.NewDecoder(r, options); err != nil {
+		return image.Config{}, err
+	} else {
+		return image.Config{
+			ColorModel: color.RGBAModel,
+			Width:      dec.GetFeatures().Width,
+			Height:     dec.GetFeatures().Height,
+		}, nil
+	}
+}
+
+// Encode picture and write to io.Writer
 func Encode(w io.Writer, src image.Image, options *encoder.Options) error {
 	if enc, err := encoder.NewEncoder(src, options); err != nil {
 		return err


### PR DESCRIPTION
Added compatibility with the standard image.Decode, with new tests to check the results. Related to #17 with improvements and new tests.
Fixed creating a new Decoder and Encoder passing nil Options and added new tests for this scenario.
Fixed deprecated methods used in tests.